### PR TITLE
Correct name of a private method in ARGBColor

### DIFF
--- a/src/main/java/fr/craftinglabs/pi/apa102/ARGBColor.java
+++ b/src/main/java/fr/craftinglabs/pi/apa102/ARGBColor.java
@@ -8,10 +8,10 @@ public class ARGBColor {
     private int brightness;
 
     public ARGBColor(int brightness, int red, int green, int blue) {
-        if (isUnder(brightness, 31)
-                || isUnder(red, 255)
-                || isUnder(green, 255)
-                || isUnder(blue, 255)) {
+        if (isAbove(brightness, 31)
+                || isAbove(red, 255)
+                || isAbove(green, 255)
+                || isAbove(blue, 255)) {
             throw new IllegalArgumentException();
         }
 
@@ -22,8 +22,8 @@ public class ARGBColor {
         this.blue = blue;
     }
 
-    private boolean isUnder(int brightness, int maxValue) {
-        return brightness > maxValue;
+    private boolean isAbove(int testedValue, int maxValue) {
+        return testedValue > maxValue;
     }
 
     public int getRed() {


### PR DESCRIPTION
the method was checking the opposite of what it's name meant. Fix the name.